### PR TITLE
FYI: Port statechart to use asyncio.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,20 +1,21 @@
-=================
-Python Statechart
-=================
+=========================
+Python Asyncio Statechart
+=========================
 
 
 .. image:: https://img.shields.io/pypi/v/statechart.svg
-        :target: https://pypi.python.org/pypi/statechart
+        :target: https://pypi.python.org/pypi/aio-statechart
 
-.. image:: https://img.shields.io/travis/leighmck/statechart.svg
-        :target: https://travis-ci.com/leighmck/statechart
+.. image:: https://img.shields.io/travis/andrewleech/aio-statechart.svg
+        :target: https://travis-ci.com/andrewleech/aio-statechart
 
-.. image:: https://readthedocs.org/projects/statechart/badge/?version=latest
-        :target: https://statechart.readthedocs.io/en/latest/?version=latest
+.. image:: https://readthedocs.org/projects/aio-statechart/badge/?version=latest
+        :target: https://aio-statechart.readthedocs.io/en/latest/?version=latest
         :alt: Documentation Status
 
 
-Python UML statechart framework
+Python UML statechart framework.
+This is an asyncio port of https://github.com/leighmck/statechart
 
 * Free software: ISC license
-* Documentation: https://statechart.readthedocs.org.
+* Documentation: https://aio-statechart.readthedocs.org.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,5 +8,6 @@ coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0
 
-pytest==6.2.4
+pytest==6.3.1
+pytest-asyncio==0.21.0
 black==21.7b0

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ requirements = [ ]
 test_requirements = ['pytest>=3', ]
 
 setup(
-    author="Leigh McKenzie",
-    author_email='maccarav0@gmail.com',
+    author="Andrew Leech, Leigh McKenzie",
+    author_email="andrew.leech@planetinnovation.com.au",
     python_requires='>=3.7',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
@@ -29,7 +29,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
     ],
-    description="Python Boilerplate contains all the boilerplate you need to create a Python package.",
+    description="State charts management library with asyncio runtime.",
     install_requires=requirements,
     license="ISC license",
     long_description=readme + '\n\n' + history,
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(include=['statechart', 'statechart.*']),
     test_suite='tests',
     tests_require=test_requirements,
-    url="https://github.com/leighmck/statechart",
+    url="https://github.com/andrewleech/aio-statechart",
     version="0.5.0",
     zip_safe=False,
 )

--- a/statechart/event.py
+++ b/statechart/event.py
@@ -32,7 +32,7 @@ class Event:
         Transition(start=a, end=b, event=my_event)
 
         Fire the event:
-        statechart.dispatch(event=my_event)
+        await statechart.dispatch(event=my_event)
 
         If the current state has an outgoing transition associated
         with the event, it may be fired if the guard condition allows.

--- a/statechart/states.py
+++ b/statechart/states.py
@@ -16,6 +16,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import logging
+from typing import List, Optional
 
 from statechart.runtime import Metadata
 
@@ -44,11 +45,6 @@ class State:
         event triggers, actions or guard conditions.
         Transition(start=a, end=b)
 
-    Note:
-        Do not dispatch a synchronous event within the action (enter, do or
-        exit) functions. If you need to dispatch an event, do so using the
-        async_dispatch function of the statechart.
-
     Raises:
         RuntimeError: If the parent context is invalid.
             Only a state chart can have no parent context.
@@ -67,7 +63,7 @@ class State:
         self.transitions = []
         self.active = False
 
-    def entry(self, event):
+    async def entry(self, event):
         """
         An optional action that is executed whenever this state is
         entered, regardless of the transition taken to reach the state. If
@@ -79,7 +75,7 @@ class State:
         """
         pass
 
-    def do(self, event):
+    async def do(self, event):
         """
         An optional action that is executed whilst this state is active.
         The execution starts after this state is entered, and stops either by
@@ -94,7 +90,7 @@ class State:
         """
         pass
 
-    def exit(self, event):
+    async def exit(self, event):
         """
         An optional action that is executed upon deactivation of this state
         regardless of which transition was taken out of the state. If defined,
@@ -127,7 +123,7 @@ class State:
         else:
             self.transitions.append(transition)
 
-    def activate(self, metadata, event):
+    async def activate(self, metadata, event):
         """
         Activate the state.
 
@@ -145,13 +141,13 @@ class State:
 
             self.context.current_state = self
 
-        if self.entry:
-            self.entry(event=event)
+        if self.entry is not None:
+            await self.entry(event=event)
 
-        if self.do:
-            self.do(event=event)
+        if self.do is not None:
+            await self.do(event=event)
 
-    def deactivate(self, metadata, event):
+    async def deactivate(self, metadata, event):
         """
         Deactivate the state.
 
@@ -161,11 +157,11 @@ class State:
         """
         self._logger.info('Deactivate "%s"', self.name)
 
-        self.exit(event=event)
+        await self.exit(event=event)
 
         self.active = False
 
-    def dispatch(self, metadata, event):
+    async def dispatch(self, metadata, event):
         """
         Dispatch transition.
 
@@ -182,7 +178,7 @@ class State:
         status = False
 
         for transition in self.transitions:
-            if transition.execute(metadata=metadata, event=event):
+            if await transition.execute(metadata=metadata, event=event):
                 status = True
                 break
 
@@ -224,11 +220,11 @@ class Context(State):
 
     def __init__(self, name, context):
         super().__init__(name=name, context=context)
-        self.initial_state = None
-        self.current_state = None
+        self.initial_state: State = None  # type: ignore
+        self.current_state: State = None  # type: ignore
         self.finished = False
 
-    def deactivate(self, metadata, event):
+    async def deactivate(self, metadata, event):
         """
         Deactivate the state.
 
@@ -236,8 +232,8 @@ class Context(State):
             metadata (Metadata): Common statechart metadata.
             event (Event): Event which led to the transition out of this state.
         """
-        super().deactivate(metadata=metadata, event=event)
-        self.current_state = None
+        await super().deactivate(metadata=metadata, event=event)
+        self.current_state = None  # type: ignore
         self.finished = False
 
     def is_active(self, state_name):
@@ -274,12 +270,12 @@ class FinalState(State):
     def add_transition(self, transition):
         raise RuntimeError('Cannot add a transition from the final state')
 
-    def activate(self, metadata, event):
-        super().activate(metadata=metadata, event=event)
+    async def activate(self, metadata, event):
+        await super().activate(metadata=metadata, event=event)
         self.context.finished = True
 
-    def deactivate(self, metadata, event):
-        super().deactivate(metadata=metadata, event=event)
+    async def deactivate(self, metadata, event):
+        await super().deactivate(metadata=metadata, event=event)
         self.context.finished = False
 
 
@@ -295,7 +291,7 @@ class ConcurrentState(State):
 
     def __init__(self, name, context):
         super().__init__(name, context)
-        self.regions = []
+        self.regions: List[CompositeState] = []
 
     def add_region(self, region):
         """
@@ -309,7 +305,7 @@ class ConcurrentState(State):
         else:
             raise RuntimeError('A concurrent state can only add composite state regions')
 
-    def activate(self, metadata, event):
+    async def activate(self, metadata, event):
         """
         Activate the state.
 
@@ -317,13 +313,13 @@ class ConcurrentState(State):
             metadata (Metadata): Common statechart metadata.
             event (Event): Event which led to the transition into this state.
         """
-        super().activate(metadata, event)
+        await super().activate(metadata, event)
         for inactive in [region for region in self.regions if not region.active]:
             # Check if region is activated implicitly via incoming transition.
-            inactive.activate(metadata=metadata, event=event)
-            inactive.initial_state.activate(metadata=metadata, event=event)
+            await inactive.activate(metadata=metadata, event=event)
+            await inactive.initial_state.activate(metadata=metadata, event=event)
 
-    def deactivate(self, metadata, event):
+    async def deactivate(self, metadata, event):
         """
         Deactivate child states within regions, then overall state.
 
@@ -335,11 +331,11 @@ class ConcurrentState(State):
 
         for region in self.regions:
             if region.active:
-                region.deactivate(metadata=metadata, event=event)
+                await region.deactivate(metadata=metadata, event=event)
 
-        super().deactivate(metadata=metadata, event=event)
+        await super().deactivate(metadata=metadata, event=event)
 
-    def dispatch(self, metadata, event):
+    async def dispatch(self, metadata, event):
         """
         Dispatch transition.
 
@@ -360,7 +356,7 @@ class ConcurrentState(State):
 
         """ Check if any of the child regions can handle the event """
         for region in self.regions:
-            if region.dispatch(metadata=metadata, event=event):
+            if await region.dispatch(metadata=metadata, event=event):
                 dispatched = True
 
         if dispatched:
@@ -414,7 +410,7 @@ class CompositeState(Context):
         if isinstance(context, ConcurrentState):
             context.add_region(self)
 
-    def activate(self, metadata, event):
+    async def activate(self, metadata, event):
         """
         Activate the state.
 
@@ -425,12 +421,12 @@ class CompositeState(Context):
             metadata (Metadata): Common statechart metadata.
             event: Event which led to the transition into this state.
         """
-        super().activate(metadata=metadata, event=event)
+        await super().activate(metadata=metadata, event=event)
 
         if metadata.transition and metadata.transition.end is self:
-            self.initial_state.activate(metadata=metadata, event=event)
+            await self.initial_state.activate(metadata=metadata, event=event)
 
-    def deactivate(self, metadata, event):
+    async def deactivate(self, metadata, event):
         """
         Deactivate the state.
 
@@ -448,11 +444,11 @@ class CompositeState(Context):
             self.history_state.state = self.current_state
 
         if self.current_state.active:
-            self.current_state.deactivate(metadata=metadata, event=event)
+            await self.current_state.deactivate(metadata=metadata, event=event)
 
-        super().deactivate(metadata=metadata, event=event)
+        await super().deactivate(metadata=metadata, event=event)
 
-    def dispatch(self, metadata, event):
+    async def dispatch(self, metadata, event):
         """
         Dispatch transition.
 
@@ -471,12 +467,12 @@ class CompositeState(Context):
 
         # See if the current child state can handle the event
         if self.current_state is None and self.initial_state:
-            self.initial_state.activate(metadata=metadata, event=None)
-            self.current_state.activate(metadata=metadata, event=event)
+            await self.initial_state.activate(metadata=metadata, event=None)
+            await self.current_state.activate(metadata=metadata, event=event)
 
         dispatched = False
 
-        if self.current_state and self.current_state.dispatch(metadata=metadata, event=event):
+        if self.current_state and await self.current_state.dispatch(metadata=metadata, event=event):
             dispatched = True
 
         if dispatched:
@@ -496,9 +492,9 @@ class CompositeState(Context):
         for transition in self.transitions:
             # If transition is local, deactivate current state if transition is allowed.
             if self._is_local_transition(transition) and transition.is_allowed(event=event):
-                self.current_state.deactivate(metadata=metadata, event=event)
+                await self.current_state.deactivate(metadata=metadata, event=event)
 
-            if transition.execute(metadata=metadata, event=event):
+            if await transition.execute(metadata=metadata, event=event):
                 return True
 
         return False
@@ -533,7 +529,7 @@ class Statechart(Context):
         super().__init__(name=name, context=None)
         self.metadata = Metadata()
 
-    def start(self):
+    async def start(self):
         """
         Initialises the Statechart in the metadata. Sets the start state.
 
@@ -544,16 +540,16 @@ class Statechart(Context):
         """
         self._logger.info('Start "%s"', self.name)
         self.active = True
-        self.initial_state.activate(metadata=self.metadata, event=None)
+        await self.initial_state.activate(metadata=self.metadata, event=None)
 
-    def stop(self):
+    async def stop(self):
         """
         Stops the statemachine by deactivating statechart and thus all it's child states.
         """
         self._logger.info('Stop "%s"', self.name)
-        self.deactivate(metadata=self.metadata, event=None)
+        await self.deactivate(metadata=self.metadata, event=None)
 
-    def deactivate(self, metadata, event):
+    async def deactivate(self, metadata, event):
         """
         Deactivate the statechart.
 
@@ -563,9 +559,9 @@ class Statechart(Context):
         """
         self._logger.info('Deactivate "%s"', self.name)
         self.active = False
-        self.current_state = None
+        self.current_state = None  # type: ignore
 
-    def dispatch(self, event):
+    async def dispatch(self, event):
         """
         Calls the dispatch method on the current state.
 
@@ -577,7 +573,7 @@ class Statechart(Context):
         """
         self.handle_internal(event=event)
 
-        return self.current_state.dispatch(metadata=self.metadata, event=event)
+        return await self.current_state.dispatch(metadata=self.metadata, event=event)
 
     def active_states(self):
         states = []
@@ -602,11 +598,11 @@ class Statechart(Context):
     def add_transition(self, transition):
         raise RuntimeError('Cannot add transition to a statechart')
 
-    def entry(self, event):
+    async def entry(self, event):
         raise RuntimeError('Cannot define an entry action for a statechart')
 
-    def do(self, event):
+    async def do(self, event):
         raise RuntimeError('Cannot define an do action for a statechart')
 
-    def exit(self, event):
+    async def exit(self, event):
         raise RuntimeError('Cannot define an exit action for a statechart')

--- a/tests/test_pseudostate.py
+++ b/tests/test_pseudostate.py
@@ -26,22 +26,24 @@ class TestInitialState:
         startchart = Statechart(name='statechart')
         InitialState(startchart)
 
-    def test_activate_initial_state(self):
+    @pytest.mark.asyncio
+    async def test_activate_initial_state(self):
         startchart = Statechart(name='statechart')
         initial_state = InitialState(startchart)
         default_state = State(name='default', context=startchart)
         Transition(start=initial_state, end=default_state)
-        startchart.start()
+        await startchart.start()
 
-        initial_state.activate(metadata=startchart.metadata, event=None)
+        await initial_state.activate(metadata=startchart.metadata, event=None)
         assert startchart.is_active('default')
 
-    def test_missing_transition_from_initial_state(self):
+    @pytest.mark.asyncio
+    async def test_missing_transition_from_initial_state(self):
         startchart = Statechart(name='statechart')
         InitialState(startchart)
 
         with pytest.raises(RuntimeError):
-            startchart.start()
+            await startchart.start()
 
     def test_multiple_transitions_from_initial_state(self):
         startchart = Statechart(name='statechart')
@@ -87,7 +89,8 @@ class TestShallowHistoryState:
         with pytest.raises(RuntimeError):
             ShallowHistoryState(composite_state)
 
-    def test_activate_shallow_history_state(self):
+    @pytest.mark.asyncio
+    async def test_activate_shallow_history_state(self):
         """
         statechart:
 
@@ -137,23 +140,24 @@ class TestShallowHistoryState:
         Transition(start=csb_state_c, end=csa_state_d, event=csb_c_to_d)
 
         # Execute statechart
-        statechart.start()
-        statechart.dispatch(csa_a_to_b)
+        await statechart.start()
+        await statechart.dispatch(csa_a_to_b)
 
         # Assert we have reached CSA child state B, history should restore this state
         assert statechart.is_active(csa_state_b.name)
 
-        statechart.dispatch(csa_to_csb)
+        await statechart.dispatch(csa_to_csb)
 
         # Assert we have reached CSB child state C
         assert statechart.is_active(csb_state_c.name)
 
-        statechart.dispatch(csb_to_csa)
+        await statechart.dispatch(csb_to_csa)
 
         # Assert the history state has restored CSA child state B,
         assert statechart.is_active(csa_state_b.name)
 
-    def test_activate_shallow_history_given_deep_history_scenario(self):
+    @pytest.mark.asyncio
+    async def test_activate_shallow_history_given_deep_history_scenario(self):
         """
         statechart:
 
@@ -216,28 +220,29 @@ class TestShallowHistoryState:
         Transition(start=csc_state_d, end=csc_state_e, event=csc_state_d_to_csc_state_d)
 
         # Execute statechart
-        statechart.start()
-        statechart.dispatch(csa_state_b_to_csb)
+        await statechart.start()
+        await statechart.dispatch(csa_state_b_to_csb)
 
         assert statechart.is_active('csb_state_b')
 
-        statechart.dispatch(csb_state_b_to_csb_state_b)
+        await statechart.dispatch(csb_state_b_to_csb_state_b)
 
         # Assert we have reached state csb_state_c, history should restore csb_state_c's parent
         # state csb
         assert statechart.is_active('csb_state_c')
 
-        statechart.dispatch(csa_to_csc)
+        await statechart.dispatch(csa_to_csc)
 
         # Assert we have reached state csc_state_d
         assert statechart.is_active('csc_state_d')
 
-        statechart.dispatch(csc_to_csa)
+        await statechart.dispatch(csc_to_csa)
 
         # Assert the history state has restored state csb
         assert statechart.is_active('csb')
 
-    def test_activate_multiple_shallow_history_states(self):
+    @pytest.mark.asyncio
+    async def test_activate_multiple_shallow_history_states(self):
         """
         statechart:
 
@@ -302,23 +307,23 @@ class TestShallowHistoryState:
         Transition(start=csc_state_d, end=csc_state_e, event=csc_state_d_to_csc_state_e)
 
         # Execute statechart
-        statechart.start()
-        statechart.dispatch(csa_state_a_to_csb)
+        await statechart.start()
+        await statechart.dispatch(csa_state_a_to_csb)
 
         assert statechart.is_active('csb_state_b')
 
-        statechart.dispatch(csb_state_b_to_csb_state_b)
+        await statechart.dispatch(csb_state_b_to_csb_state_b)
 
         # Assert we have reached state csb_state_c, csb's history state should restore
         # this state
         assert statechart.is_active('csb_state_c')
 
-        statechart.dispatch(csa_to_csc)
+        await statechart.dispatch(csa_to_csc)
 
         # Assert we have reached state csc_state_d
         assert statechart.is_active('csc_state_d')
 
-        statechart.dispatch(csc_to_sca)
+        await statechart.dispatch(csc_to_sca)
 
         # Assert the history state has restored state csb_state_c
         assert statechart.is_active('csb_state_c')
@@ -333,7 +338,8 @@ class TestChoiceState:
     @pytest.mark.parametrize('state_name, expected_state_name',
                              [('a', 'a'),
                               ('b', 'b')])
-    def test_choice_state_transitions(self, state_name, expected_state_name):
+    @pytest.mark.asyncio
+    async def test_choice_state_transitions(self, state_name, expected_state_name):
         def is_a(**kwargs):
             return state_name == 'a'
 
@@ -350,6 +356,6 @@ class TestChoiceState:
         Transition(start=choice, end=state_a, event=None, guard=is_a)
         Transition(start=choice, end=state_b, event=None, guard=None)  # else
 
-        statechart.start()
+        await statechart.start()
 
         assert statechart.is_active(expected_state_name)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -20,10 +20,10 @@ from statechart import InitialState, State, Statechart, Transition
 
 
 @pytest.fixture
-def state():
+async def state():
     statechart = Statechart(name='statechart')
     initial_state = InitialState(statechart)
     next_state = State(name='next', context=statechart)
     Transition(initial_state, next_state)
-    statechart.start()
+    await statechart.start()
     return next_state


### PR DESCRIPTION
Hi @leighmck, this PR is not intended for merge, more just wanted to let you know I've made a version of this for asyncio usage. 

As is always the case with aio it's a very pervasive change, it's not really possible to have a single codebase work for both aio and "normal" synchronous code. I'm more than happy to keep my port updated to match your original one here as needed though!

Note: while I've updated the readme to point to `aio-statechart` branded badges & docs I haven't created these resources as-yet. I may end up publishing the port under that name, though for now I'm intending to use it as a submodule instead of a pip installed package.

